### PR TITLE
wpanusb: enhancement for beagleconnect freedom gateway

### DIFF
--- a/scripts/rmmod.sh
+++ b/scripts/rmmod.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+rmmod wpanusb
+rmmod ieee802154_6lowpan
+rmmod ieee802154_socket
+rmmod mac802154
+rmmod ieee802154
+

--- a/wpanusb.h
+++ b/wpanusb.h
@@ -32,7 +32,7 @@ enum wpanusb_requests {
 	SET_FRAME_RETRIES,
 	SET_PROMISCUOUS_MODE,
 	GET_EXTENDED_ADDR,
-	GET_CAPABILITIES,
+	GET_SUPPORTED_CHANNELS,
 };
 
 struct set_channel {


### PR DESCRIPTION
Hi @statropy , 

can you please review this PR,
All changes tested BeagleConnect Freedom Rev C2 device:

* get valid channels from device (was marked TODO)
* disable IEEE802154_HW_PROMISCUOUS mode to  disable error is kernel logs
* with the changes Sub-G(with zephyr patch for PA) works without issues
* 2.4G fails at setting channel
* add simple rmmod script to remove associated modules, useful during
  driver testing

SubG host(valid channels received from gateway device):

vaishnav@spectre:~/freedom/wpanusb$ sudo ./scripts/modprobe.sh
vaishnav@spectre:~/freedom/wpanusb$ sudo scripts/lowpan.sh 2 1
Using phy phy0 channel 1 PAN ID 0xabcd
IP: 2001:db8::2/64 Short: 0xbee2
Cannot find device "lowpan0"
vaishnav@spectre:~/freedom/wpanusb$ ping6 2001:db8::1
PING 2001:db8::1(2001:db8::1) 56 data bytes
64 bytes from 2001:db8::1: icmp_seq=1 ttl=64 time=67.7 ms
64 bytes from 2001:db8::1: icmp_seq=2 ttl=64 time=39.2 ms
64 bytes from 2001:db8::1: icmp_seq=3 ttl=64 time=40.5 ms
64 bytes from 2001:db8::1: icmp_seq=4 ttl=64 time=38.9 ms
64 bytes from 2001:db8::1: icmp_seq=5 ttl=64 time=38.9 ms
64 bytes from 2001:db8::1: icmp_seq=6 ttl=64 time=38.9 ms
64 bytes from 2001:db8::1: icmp_seq=7 ttl=64 time=39.2 ms
64 bytes from 2001:db8::1: icmp_seq=8 ttl=64 time=38.9 ms
64 bytes from 2001:db8::1: icmp_seq=9 ttl=64 time=39.2 ms
64 bytes from 2001:db8::1: icmp_seq=10 ttl=64 time=39.0 ms
^C
--- 2001:db8::1 ping statistics ---
10 packets transmitted, 10 received, 0% packet loss, time 9013ms
rtt min/avg/max/mdev = 38.864/42.039/67.686/8.560 ms

vaishnav@spectre:~/freedom/wpanusb$ iwpan phy
wpan_phy phy0
supported channels:
        page 0: 0,1,2,3,4,5,6,7,8,9,10
current_page: 0
current_channel: 1,   906 MHz
tx_power: 3
capabilities:
        iftypes: node
        channels:
                page 0:
                        [ 0] 868.3 MHz, [ 1]   906 MHz, [ 2]   908 MHz,
                        [ 3]   910 MHz, [ 4]   912 MHz, [ 5]   914 MHz,
                        [ 6]   916 MHz, [ 7]   918 MHz, [ 8]   920 MHz,
                        [ 9]   922 MHz, [10]   924 MHz
        tx_powers:
                        3 dBm, 2.8 dBm, 2.3 dBm, 1.8 dBm, 1.3 dBm, 0.7 dBm,
                        0 dBm, -1 dBm, -2 dBm, -3 dBm, -4 dBm, -5 dBm,
                        -7 dBm, -9 dBm, -12 dBm, -17 dBm,
        min_be: 3
        max_be: 5
        csma_backoffs: 4
        frame_retries: 3
        lbt: false

SubG Zephyr Console:

** Booting Zephyr OS version 2.4.99  ***
[00:00:00.005,462] <inf> wpanusb_bc: Starting wpanusb
[00:00:00.006,652] <err> wpanusb_bc: Dropped HDLC crc:f399 len:4
[00:00:00.706,298] <err> wpanusb_bc: RETRY HDLC INIT
[00:00:00.707,427] <inf> wpanusb_bc: HDLC Ready
[00:00:55.224,395] <err> wpanusb_bc: 11: Not handled for now
[00:00:55.229,095] <err> wpanusb_bc: 11: Not handled for now
[00:00:55.251,098] <inf> wpanusb_bc: pan id : FFFF
[00:00:55.255,737] <inf> wpanusb_bc: short addr : FFFF
[00:00:55.256,958] <inf> wpanusb_bc: Start IEEE 802.15.4 device
[00:01:06.258,544] <inf> wpanusb_bc: Stop IEEE 802.15.4 device
[00:01:06.268,096] <inf> wpanusb_bc: page 0 channel 1
[00:01:06.275,634] <inf> wpanusb_bc: pan id : ABCD
[00:01:06.278,930] <inf> wpanusb_bc: short addr : BEE2
[00:01:06.282,104] <inf> wpanusb_bc: Start IEEE 802.15.4 device
[00:01:48.053,558] <inf> wpanusb_bc: Stop IEEE 802.15.4 device